### PR TITLE
 [2024/07/25]feat/#43 users backoffice front

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,42 +1,52 @@
 import React from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import './styles/App.css';
-import IndexImage from './assets/index_picture.png'
+import IndexImage from './assets/index_picture.png';
 import Header from './components/Header';
+import AdminHeader from './components/AdminHeader';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
 import PostListPage from './pages/PostListPage';
 import PostDetailPage from './pages/PostDetailPage';
 import PetCardPostPage from './pages/PetCardPostPage';
 import FacilityFinderPage from './pages/FacilityFinderPage';
+import AdminUserListPage from './pages/Admin/AdminUserListPage';
+import AdminReportListPage from './pages/Admin/AdminReportListPage';
 
 function App() {
   return (
     <Router>
       <div className="App">
-        <Header />
         <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/signup" element={<SignupPage />} />
-          <Route path="/community" element={<PostListPage category="DEFAULT" />} />
-          <Route path="/gallery" element={<PostListPage category="BOAST" />} />
-          <Route path="/freedom" element={<PostListPage category="FREEDOM" />} />
-          <Route path="/pet/:id" element={<PetCardPostPage />} />
-          <Route path="/posts/:id" element={<PostDetailPage />} />
-          <Route path="/facility-finder" element={<FacilityFinderPage />} />
-          </Routes>
+          {/* 메인 애플리케이션 경로 */}
+          <Route path="/" element={<><Header /><HomePage /></>} />
+          <Route path="/login" element={<><Header /><LoginPage /></>} />
+          <Route path="/signup" element={<><Header /><SignupPage /></>} />
+          <Route path="/community" element={<><Header /><PostListPage category="DEFAULT" /></>} />
+          <Route path="/gallery" element={<><Header /><PostListPage category="BOAST" /></>} />
+          <Route path="/freedom" element={<><Header /><PostListPage category="FREEDOM" /></>} />
+          <Route path="/pet/:id" element={<><Header /><PetCardPostPage /></>} />
+          <Route path="/posts/:id" element={<><Header /><PostDetailPage /></>} />
+          <Route path="/facility-finder" element={<><Header /><FacilityFinderPage /></>} />
+
+          {/* 백오피스 경로 */}
+          <Route path="/admin/*" element={<><AdminHeader /><Routes>
+            <Route path="users-manager" element={<AdminUserListPage />} />
+            <Route path="reports-view" element={<AdminReportListPage />} />
+          </Routes></>} />
+        </Routes>
       </div>
     </Router>
   );
 }
 
+// 홈 페이지
 function HomePage() {
   return (
     <div>
       <h1>나만, 펫</h1>
       <img src={IndexImage} alt="대표이미지" className="index-image" />
-      </div>
+    </div>
   );
 }
 

--- a/src/components/AdminHeader.jsx
+++ b/src/components/AdminHeader.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { NavLink, useNavigate } from 'react-router-dom';
+import styles from '../styles/Header.module.css';
+import logo from '../assets/logo.png'; // 로고 이미지 파일 경로
+import DropdownMenu from './DropdownMenu';
+
+function Header() {
+    const [user, setUser] = useState({ nickname: '', role: '' });
+    const navigate = useNavigate();
+
+    const handleLoginClick = () => {
+        navigate('/login'); 
+    };
+
+    const handleSignupClick = () => {
+        navigate('/signup');
+    };
+
+    return (
+        <header className={styles.header}>
+            <div className={styles.headerContainer}>
+                <div className={styles.logoContainer}>
+                    <NavLink to="/">
+                        <img src={logo} alt="로고" className={styles.logo} />
+                    </NavLink>
+                    <NavLink to="/admin/users-manager" className={styles.headerTitle}>나만, 펫</NavLink>
+                </div>
+                <nav className={styles.nav}>
+                    <NavLink to="/admin/users-manager" className={({ isActive }) => isActive ? styles.navLink + ' ' + styles.active : styles.navLink}>
+                        회원 관리
+                    </NavLink>
+                    <NavLink to="/admin/reports-view" className={({ isActive }) => isActive ? styles.navLink + ' ' + styles.active : styles.navLink}>
+                        신고 목록
+                    </NavLink>
+                </nav>
+                <div className={styles.headerButtons}>
+                    {/* api 연동 후 로그인 전에는 로그인, 회원가입이 나오고 아니면 dropdownmenu가 보이도록 해주시면됩니다. 
+                        어드민 헤더에서는 닉네임만 띄우도록 할 예정*/}
+                    <button className={styles.button} onClick={handleLoginClick}>로그인</button>
+                    <button className={styles.button} onClick={handleSignupClick}>회원가입</button>
+                    <DropdownMenu nickname={user.nickname} role={user.role} />
+                </div>
+            </div>
+        </header>
+    );
+}
+
+export default Header;

--- a/src/components/PaginationButton.jsx
+++ b/src/components/PaginationButton.jsx
@@ -1,0 +1,38 @@
+// src/components/PaginationButton.jsx
+import React from 'react';
+import styles from '../styles/PaginationButton.module.css'; // 스타일을 위한 CSS 모듈
+
+const PaginationButton = ({ currentPage, totalPages, onPageChange }) => {
+    const getPaginationButtons = () => {
+        const maxButtons = 5;
+        let startPage = Math.max(1, currentPage - Math.floor(maxButtons / 2));
+        let endPage = startPage + maxButtons - 1;
+
+        if (endPage > totalPages) {
+            endPage = totalPages;
+            startPage = Math.max(1, endPage - maxButtons + 1);
+        }
+
+        const buttons = [];
+        for (let i = startPage; i <= endPage; i++) {
+            buttons.push(
+                <button
+                    key={i}
+                    onClick={() => onPageChange(i)}
+                    className={currentPage === i ? styles.active : ''}
+                >
+                    {i}
+                </button>
+            );
+        }
+        return buttons;
+    };
+
+    return (
+        <div className={styles.pagination}>
+            {getPaginationButtons()}
+        </div>
+    );
+};
+
+export default PaginationButton;

--- a/src/components/PostList.jsx
+++ b/src/components/PostList.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import styles from '../styles/PostList.module.css';
+import PaginationButton from '../components/PaginationButton'; // PaginationButton 컴포넌트 import
 
 const PostList = ({ category }) => {
     const navigate = useNavigate();
@@ -56,35 +57,10 @@ const PostList = ({ category }) => {
         }));
     };
 
-    const paginate = (pageNumber) => {
+    const handlePageChange = (pageNumber) => {
         if (pageNumber >= 1 && pageNumber <= totalPages) {
             setCurrentPage(pageNumber);
         }
-    };
-
-    const getPaginationButtons = () => {
-        const maxButtons = 5;
-        let startPage = Math.max(1, currentPage - Math.floor(maxButtons / 2));
-        let endPage = startPage + maxButtons - 1;
-
-        if (endPage > totalPages) {
-            endPage = totalPages;
-            startPage = Math.max(1, endPage - maxButtons + 1);
-        }
-
-        const buttons = [];
-        for (let i = startPage; i <= endPage; i++) {
-            buttons.push(
-                <button
-                    key={i}
-                    onClick={() => paginate(i)}
-                    className={currentPage === i ? styles.active : ''}
-                >
-                    {i}
-                </button>
-            );
-        }
-        return buttons;
     };
 
     const navigateToPost = (post) => {
@@ -127,9 +103,11 @@ const PostList = ({ category }) => {
                 </tbody>
             </table>
 
-            <div className={styles.pagination}>
-                {getPaginationButtons()}
-            </div>
+            <PaginationButton
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={handlePageChange}
+            />
         </div>
     );
 };

--- a/src/components/UserList.jsx
+++ b/src/components/UserList.jsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import styles from '../styles/UserList.module.css';
+import PaginationButton from '../components/PaginationButton'; 
+
+const UserList = () => {
+    // 예시 데이터 (11개)
+    const users = [
+        { id: 1, email: 'user1@example.com', role: 'Admin', status: 'Active', warningCount: 1, signUpDate: '2023-01-15' },
+        { id: 2, email: 'user2@example.com', role: 'User', status: 'Inactive', warningCount: 0, signUpDate: '2023-02-20' },
+        { id: 3, email: 'user3@example.com', role: 'Moderator', status: 'Active', warningCount: 2, signUpDate: '2023-03-10' },
+        { id: 4, email: 'user4@example.com', role: 'Admin', status: 'Active', warningCount: 0, signUpDate: '2023-04-05' },
+        { id: 5, email: 'user5@example.com', role: 'User', status: 'Inactive', warningCount: 1, signUpDate: '2023-05-15' },
+        { id: 6, email: 'user6@example.com', role: 'Moderator', status: 'Active', warningCount: 0, signUpDate: '2023-06-20' },
+        { id: 7, email: 'user7@example.com', role: 'Admin', status: 'Inactive', warningCount: 2, signUpDate: '2023-07-10' },
+        { id: 8, email: 'user8@example.com', role: 'User', status: 'Active', warningCount: 1, signUpDate: '2023-08-25' },
+        { id: 9, email: 'user9@example.com', role: 'Moderator', status: 'Inactive', warningCount: 0, signUpDate: '2023-09-30' },
+        { id: 10, email: 'user10@example.com', role: 'Admin', status: 'Active', warningCount: 2, signUpDate: '2023-10-12' },
+        { id: 11, email: 'user11@example.com', role: 'User', status: 'Inactive', warningCount: 1, signUpDate: '2023-11-01' },
+    ];
+
+    const [currentPage, setCurrentPage] = useState(1);
+    const usersPerPage = 10; 
+    const totalPages = Math.ceil(users.length / usersPerPage);
+
+
+    const paginatedUsers = users.slice(
+        (currentPage - 1) * usersPerPage,
+        currentPage * usersPerPage
+    );
+
+    const handlePageChange = (pageNumber) => {
+        setCurrentPage(pageNumber);
+    };
+
+    return (
+        <div className={styles.container}>
+            <h2 className={styles.heading}>유저 목록</h2>
+            <table className={styles.table}>
+                <thead>
+                    <tr>
+                        <th>이메일</th>
+                        <th>유저 권한</th>
+                        <th>유저 상태</th>
+                        <th>누적 경고 수</th>
+                        <th>가입 일자</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {paginatedUsers.length > 0 ? (
+                        paginatedUsers.map(user => (
+                            <tr key={user.id}>
+                                <td>{user.email}</td>
+                                <td>{user.role}</td>
+                                <td>{user.status}</td>
+                                <td>{user.warningCount}</td>
+                                <td>{user.signUpDate}</td>
+                            </tr>
+                        ))
+                    ) : (
+                        <tr>
+                            <td colSpan="5">유저가 없습니다.</td>
+                        </tr>
+                    )}
+                </tbody>
+            </table>
+
+            <PaginationButton
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={handlePageChange}
+            />
+        </div>
+    );
+};
+
+export default UserList;

--- a/src/pages/Admin/AdminUserListPage.jsx
+++ b/src/pages/Admin/AdminUserListPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import UserList from '../../components/UserList';
+
+const AdminUserListPage = () => {
+    return (
+        <div className="admin-user-list-page">
+            <UserList />
+        </div>
+    );
+};
+
+export default AdminUserListPage;

--- a/src/styles/PaginationButton.module.css
+++ b/src/styles/PaginationButton.module.css
@@ -1,0 +1,26 @@
+/* src/styles/PaginationButton.module.css */
+.pagination {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+}
+
+.pagination button {
+    background-color: #864e5d;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    margin: 0 5px;
+    cursor: pointer;
+    border-radius: 4px;
+    font-size: 16px;
+}
+
+.pagination button:hover {
+    background-color: #673d48;
+}
+
+.pagination button.active {
+    background-color: #333;
+    color: white;
+}

--- a/src/styles/PostList.module.css
+++ b/src/styles/PostList.module.css
@@ -23,7 +23,6 @@
 
 .table th {
     background-color: white;
-    /* color: white; */
     font-weight: bold;
     text-transform: uppercase;
     border-bottom: 2px solid #ddd; /* 헤더와 본문 사이의 두꺼운 하단 경계선 */
@@ -50,35 +49,10 @@
 .table tr:hover {
     background-color: #f1f1f1;
 }
-.pagination {
-    display: flex;
-    justify-content: center;
-    margin-top: 20px;
-}
 
-.pagination button {
-    background-color: #864e5d;
-    color: white;
-    border: none;
-    padding: 10px 20px;
-    margin: 0 5px;
-    cursor: pointer;
-    border-radius: 4px;
-    font-size: 16px;
-}
-
-.pagination button:hover {
-    background-color: #673d48;
-}
-
-.pagination button.active {
-    background-color: #333;
-    color: white;
-}
 .clickableRow {
     cursor: pointer; /* 마우스 커서를 링크 클릭할 때처럼 바꾸기 위한 스타일 */
 }
-
 
 /* 카테고리 열 너비 줄이기 */
 .table th:nth-child(1),

--- a/src/styles/UserList.module.css
+++ b/src/styles/UserList.module.css
@@ -1,0 +1,80 @@
+/* src/styles/UserList.module.css */
+.container {
+    padding: 20px;
+}
+
+.heading {
+    text-align: center;
+    margin-bottom: 20px;
+    font-size: 24px;
+    font-weight: bold;
+    color: #333;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse; /* 셀 사이의 경계선 병합 */
+}
+
+.table th, .table td {
+    padding: 12px 15px;
+    text-align: left;
+}
+
+.table th {
+    background-color: white;
+    /* color: white; */
+    font-weight: bold;
+    text-transform: uppercase;
+    border-bottom: 2px solid #ddd; /* 헤더와 본문 사이의 두꺼운 하단 경계선 */
+}
+
+.table td {
+    background-color: #fff;
+    border-bottom: 1px solid #ddd; /* 각 행의 하단 경계선 */
+}
+
+/* 세로선을 숨기기 위한 스타일 */
+.table td {
+    border-right: none; /* 오른쪽 경계선 숨김 */
+}
+
+.table tr:last-child td {
+    border-bottom: none; /* 마지막 행의 하단 경계선 제거 */
+}
+
+.table tr:nth-child(even) {
+    background-color: #f9f9f9;
+}
+
+.table tr:hover {
+    background-color: #f1f1f1;
+}
+.pagination {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+}
+
+.pagination button {
+    background-color: #864e5d;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    margin: 0 5px;
+    cursor: pointer;
+    border-radius: 4px;
+    font-size: 16px;
+}
+
+.pagination button:hover {
+    background-color: #673d48;
+}
+
+.pagination button.active {
+    background-color: #333;
+    color: white;
+}
+.clickableRow {
+    cursor: pointer; /* 마우스 커서를 링크 클릭할 때처럼 바꾸기 위한 스타일 */
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #43 

## 📝작업 내용

> 전체 회원 조회 목록 구현
> 어드민 페이지 구현
> 기존 postList 페이지네이션버튼 컴포넌트 분리


`http://localhost:3000/admin/users-manager` 로 접근 가능합니다.

![image](https://github.com/user-attachments/assets/fb45afda-08af-408c-ab47-bb1aa360e315)
admin 페이지에서는 로그인/회원가입 기능 없이 닉네임만 보이게 헤더 수정 예정입니다.
신고 목록 조회에서 같이 구현하도록 하겠습니다!