### PR TITLE
[2024/07/28]feat/#26 link login backend

### DIFF
--- a/src/components/AdminHeader.jsx
+++ b/src/components/AdminHeader.jsx
@@ -1,12 +1,22 @@
-import React, { useState } from 'react';
-import { NavLink, useNavigate } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { NavLink } from 'react-router-dom';
 import styles from '../styles/AdminHeader.module.css';
 import logo from '../assets/logo.png'; // 로고 이미지 파일 경로
 import DropdownMenu from './DropdownMenu';
 
 function Header() {
-    const [user, setUser] = useState({ nickname: '', role: '' });
-    const navigate = useNavigate();
+
+    const [user, setUser] = useState({ nickname: '', role: '', accessToken: '' });
+
+    useEffect(() => {
+        const storedNickname = localStorage.getItem('nickname');
+        const storedrole = localStorage.getItem('userRole');
+        const storedAccessToken = localStorage.getItem('accessToken');
+
+        if (storedNickname && storedrole && storedAccessToken) {
+            setUser({ nickname: storedNickname, role: storedrole, accessToken: storedAccessToken });
+        }
+    }, []);
 
 
     return (
@@ -27,8 +37,6 @@ function Header() {
                     </NavLink>
                 </nav>
                 <div className={styles.headerButtons}>
-                    {/* api 연동 후 로그인 전에는 로그인, 회원가입이 나오고 아니면 dropdownmenu가 보이도록 해주시면됩니다. 
-                        어드민 헤더에서는 닉네임만 띄우도록 할 예정*/}
                     <DropdownMenu nickname={user.nickname} role={user.role} />
                 </div>
             </div>

--- a/src/components/DropdownMenu.jsx
+++ b/src/components/DropdownMenu.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { NavLink } from 'react-router-dom';
 import styles from '../styles/DropdownMenu.module.css';
 
-function DropdownMenu() {
+function DropdownMenu({ nickname, role }) {
     const [isOpen, setIsOpen] = useState(false);
     const menuRef = useRef(null);
 
@@ -25,13 +25,12 @@ function DropdownMenu() {
 
     return (
         <div className={styles.dropdownMenu} ref={menuRef}>
-            <button onClick={toggleMenu} className={styles.button}>닉네임
-                {/* 로그인한 사용자 닉네임이 나오도록함. */}
-            </button>
+            <button onClick={toggleMenu} className={styles.button}>{nickname}</button>
             <div className={`${styles.dropdownContent} ${isOpen ? styles.show : ''}`}>
                 <NavLink to="/profile">MyPage</NavLink>
-                <NavLink to="/admin/user-list">BackOffice</NavLink>
-                {/* 백오피스는 로그인한 사용자가 admin 권한일때 되도록합니다. */}
+                {(role === 'ROLE_ADMIN' || role === 'ROLE_MANAGER') && (
+                    <NavLink to="/admin/user-list">BackOffice</NavLink>
+                )}
                 <NavLink to="/logout">Log Out</NavLink>
             </div>
         </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,12 +1,23 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import styles from '../styles/Header.module.css';
 import logo from '../assets/logo.png'; // 로고 이미지 파일 경로
 import DropdownMenu from './DropdownMenu';
 
 function Header() {
-    const [user, setUser] = useState({ nickname: '', role: '' });
+
+    const [user, setUser] = useState({ nickname: '', role: '', accessToken: '' });
     const navigate = useNavigate();
+
+    useEffect(() => {
+        const storedNickname = localStorage.getItem('nickname');
+        const storedrole = localStorage.getItem('userRole');
+        const storedAccessToken = localStorage.getItem('accessToken');
+
+        if (storedNickname && storedrole && storedAccessToken) {
+            setUser({ nickname: storedNickname, role: storedrole, accessToken: storedAccessToken });
+        }
+    }, []);
 
     const handleLoginClick = () => {
         navigate('/login');
@@ -40,10 +51,14 @@ function Header() {
                     </NavLink>
                 </nav>
                 <div className={styles.headerButtons}>
-                    {/* api 연동 후 로그인 전에는 로그인, 회원가입이 나오고 아니면 dropdownmenu가 보이도록 해주시면됩니다. */}
-                    <button className={styles.button} onClick={handleLoginClick}>로그인</button>
-                    <button className={styles.button} onClick={handleSignupClick}>회원가입</button>
-                    <DropdownMenu nickname={user.nickname} role={user.role} />
+                    {user.accessToken ? (
+                        <DropdownMenu nickname={user.nickname} role={user.role} />
+                    ) : (
+                        <>
+                            <button className={styles.button} onClick={handleLoginClick}>로그인</button>
+                            <button className={styles.button} onClick={handleSignupClick}>회원가입</button>
+                        </>
+                    )}
                 </div>
             </div>
         </header>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#26 

## 📝작업 내용

- 로그인 기능 연동 및 로그인 상태 헤더 구현
- 로그인 시, 드롭다운메뉴 `UserRole`에 따라 `BackOffice` 표시되도록 구현 
- BackOffice 페이지의 Admin Header도 동일하게 구현

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/04091a31-bb83-4ff7-95d9-1e39489fcfda)
![image](https://github.com/user-attachments/assets/ff5e24a4-de00-42af-b495-71a54210329d)
![image](https://github.com/user-attachments/assets/91aec126-8ce1-4e70-a52d-ea8f3471a995)
![image](https://github.com/user-attachments/assets/54dc50a8-0038-445c-b52e-bea16df3ec93)
![image](https://github.com/user-attachments/assets/aafc1600-44f5-4689-b5a1-96b12c6730e9)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
