### PR TITLE
[2024/07/28]feat/#64 link logout backend

### DIFF
--- a/src/components/DropdownMenu.jsx
+++ b/src/components/DropdownMenu.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
 import styles from '../styles/DropdownMenu.module.css';
+import handleLogout from './Logout';
 
 function DropdownMenu({ nickname, role }) {
     const [isOpen, setIsOpen] = useState(false);
     const menuRef = useRef(null);
+    const navigate = useNavigate();
 
     const toggleMenu = () => {
         setIsOpen(!isOpen);
@@ -31,7 +33,7 @@ function DropdownMenu({ nickname, role }) {
                 {(role === 'ROLE_ADMIN' || role === 'ROLE_MANAGER') && (
                     <NavLink to="/admin/user-list">BackOffice</NavLink>
                 )}
-                <NavLink to="/logout">Log Out</NavLink>
+                <button type='button' onClick={() => handleLogout(navigate)} className={styles.logoutButton}>Log Out</button>
             </div>
         </div>
     );

--- a/src/components/DropdownMenu.jsx
+++ b/src/components/DropdownMenu.jsx
@@ -33,7 +33,7 @@ function DropdownMenu({ nickname, role }) {
                 {(role === 'ROLE_ADMIN' || role === 'ROLE_MANAGER') && (
                     <NavLink to="/admin/user-list">BackOffice</NavLink>
                 )}
-                <button type='button' onClick={() => handleLogout(navigate)} className={styles.logoutButton}>Log Out</button>
+                <button onClick={() => handleLogout(navigate)} className={styles.logoutButton}>Log Out</button>
             </div>
         </div>
     );

--- a/src/components/Logout.jsx
+++ b/src/components/Logout.jsx
@@ -1,6 +1,8 @@
 import axios from 'axios';
+import refreshAccessToken from './refreshToken';
 
 const handleLogout = async (navigate) => {
+
   try {
     // 로컬 스토리지에서 액세스 토큰 가져오기
     const accessToken = localStorage.getItem('accessToken');
@@ -24,15 +26,24 @@ const handleLogout = async (navigate) => {
       localStorage.removeItem('userRole');
       localStorage.removeItem('userId')
 
+      alert('로그아웃이 완료 되었습니다.');
+
       // 로그아웃 후 리다이렉트
       navigate('/');
       window.location.reload();
     } else {
-      alert('로그아웃 중 오류가 발생했습니다.')
+      console.log('로그아웃 중 오류가 발생했습니다.');
     }
   } catch (error) {
     console.error('로그아웃 중 오류가 발생했습니다.', error);
-    alert(`${error.response.data.message}` || '로그아웃 중 오류가 발생했습니다.');
+
+    // 에러 상태코드 '401' 이고, 서버의 응답 데이터가 'Expired-Token'인 경우 토큰 리프레쉬
+    if (error.response.status == 401 && error.response.data.data == 'Expired-Token') {
+      await refreshAccessToken();
+      handleLogout(navigate); // 다시 수행하고 있던 함수 재호출
+    } else {
+      alert(`${error.response.data.message}` || '로그아웃 중 오류가 발생했습니다.');
+    }
   }
 };
 

--- a/src/components/Logout.jsx
+++ b/src/components/Logout.jsx
@@ -1,0 +1,39 @@
+import axios from 'axios';
+
+const handleLogout = async (navigate) => {
+  try {
+    // 로컬 스토리지에서 액세스 토큰 가져오기
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) {
+      console.error('액세스 토큰이 없습니다.');
+      return;
+    }
+
+    // 로그아웃 API 호출
+    const response = await axios.post(
+      'http://localhost:8080/api/auth/logout', {
+    }, {
+      headers: { Authorization: `Bearer ${accessToken}` }, // 'Bearer ' 문구 포함 엑세스 토큰
+      withCredentials: true
+    });
+
+    if (response.status == 200) {
+      // 로컬 스토리지에서 사용자 정보 제거
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('nickname');
+      localStorage.removeItem('userRole');
+      localStorage.removeItem('userId')
+
+      // 로그아웃 후 리다이렉트
+      navigate('/');
+      window.location.reload();
+    } else {
+      alert('로그아웃 중 오류가 발생했습니다.')
+    }
+  } catch (error) {
+    console.error('로그아웃 중 오류가 발생했습니다.', error);
+    alert(`${error.response.data.message}` || '로그아웃 중 오류가 발생했습니다.');
+  }
+};
+
+export default handleLogout;

--- a/src/components/refreshToken.jsx
+++ b/src/components/refreshToken.jsx
@@ -1,0 +1,24 @@
+import axios from 'axios';
+
+const refreshAccessToken = async () => {
+    try {
+        // refresh token을 포함한 요청을 서버로 보냄
+        const response = await axios.post(
+            'http://localhost:8080/api/auth/refresh', {
+        }, { withCredentials: true } // 쿠키를 포함하여 요청
+        );
+
+        if (response.status == 200) {
+            // 새로운 액세스 토큰을 로컬 스토리지에 저장
+            const newAccessToken = response.headers['authorization'];
+            localStorage.setItem('accessToken', newAccessToken.replace('Bearer ', ''));
+            console.log('토큰 재발급이 완료 되었습니다!');
+        } else {
+            console.log('토큰 재발급 실패!!');
+        }
+    } catch (error) {
+        console.error('Failed to refresh access token', error.response.data.message);
+    }
+};
+
+export default refreshAccessToken;

--- a/src/styles/DropdownMenu.module.css
+++ b/src/styles/DropdownMenu.module.css
@@ -38,3 +38,17 @@
     border: none;
     border-radius: 0.25rem;
 }
+
+.logoutButton {
+    cursor: pointer;
+    min-width: 160px;
+    padding: 12px 16px;
+    font-size: 1rem;
+    color: black;
+    background-color: #fff;
+    border: none;
+}
+
+.logoutButton:hover {
+    background-color: #f1f1f1;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#64 

## 📝작업 내용

- `DropdawnMenu`의 `logout` 버튼 기능 연동
- 리프레쉬 토큰 기능 연동

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 스크린샷 (선택)

- 리프레쉬 토큰 기능을 로그아웃에 적용한 내용입니다.
![image](https://github.com/user-attachments/assets/abe7e7ef-4c9c-4475-8a97-2b0473f6bb55)

해당하는 기능(여기서는 로그아웃)의 서버의 API를 호출하는 `axios`의 try-catch 문의 catch문에 위 사진을 참고해서 적용하면 됩니다!


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
