### PR TITLE
[2024/07/31]refactor/#105 post page refactor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,8 @@ import FacilityFinderPage from './pages/FacilityFinderPage';
 import AdminUserListPage from './pages/Admin/AdminUserListPage';
 import AdminReportListPage from './pages/Admin/AdminReportListPage';
 import ProfilePage from './pages/ProfilePage';
-import AccessDeniedPage from './pages/AccessDeniedPage'; // 접근 불가 페이지 추가
+import MyPostListPage from './pages/MyPostListPage'; // 페이지 이름이 아니라 컴포넌트 이름이 일치하는지 확인
+import AccessDeniedPage from './pages/AccessDeniedPage';
 import ProtectedRoute from './ProtectedRoute';
 
 const MainLayout = () => (
@@ -47,7 +48,8 @@ function App() {
             <Route path="/posts/:id" element={<PostDetailPage />} />
             <Route path="/facility-finder" element={<FacilityFinderPage />} />
             <Route path="/profile" element={<ProfilePage />} />
-            <Route path="/access-denied" element={<AccessDeniedPage />} /> {/* 접근 불가 페이지 추가 */}
+            <Route path="/my-post-list/:email" element={<MyPostListPage />} /> {/* 수정된 부분 확인 */}
+            <Route path="/access-denied" element={<AccessDeniedPage />} />
           </Route>
 
           {/* 백오피스 경로 */}

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import FacilityFinderPage from './pages/FacilityFinderPage';
 import AdminUserListPage from './pages/Admin/AdminUserListPage';
 import AdminReportListPage from './pages/Admin/AdminReportListPage';
 import ProfilePage from './pages/ProfilePage';
-import MyPostListPage from './pages/MyPostListPage'; // 페이지 이름이 아니라 컴포넌트 이름이 일치하는지 확인
+import MyPostListPage from './pages/MyPostListPage';
 import AccessDeniedPage from './pages/AccessDeniedPage';
 import ProtectedRoute from './ProtectedRoute';
 
@@ -48,7 +48,7 @@ function App() {
             <Route path="/posts/:id" element={<PostDetailPage />} />
             <Route path="/facility-finder" element={<FacilityFinderPage />} />
             <Route path="/profile" element={<ProfilePage />} />
-            <Route path="/my-post-list/:email" element={<MyPostListPage />} /> {/* 수정된 부분 확인 */}
+            <Route path="/my-post-list/:email" element={<MyPostListPage />} />
             <Route path="/access-denied" element={<AccessDeniedPage />} />
           </Route>
 

--- a/src/components/MyPostList.jsx
+++ b/src/components/MyPostList.jsx
@@ -1,0 +1,124 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import axios from 'axios';
+import styles from '../styles/PostList.module.css';
+import PaginationButton from '../components/PaginationButton';
+
+const MyPostList = () => {
+  const navigate = useNavigate();
+  const { email } = useParams(); // URL 파라미터에서 이메일을 추출합니다.
+  const [posts, setPosts] = useState([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [nickname, setNickname] = useState('');
+  const postsPerPage = 10;
+
+  useEffect(() => {
+    // 닉네임을 로컬 스토리지에서 가져오는 함수
+    const fetchNickname = () => {
+      const storedNickname = localStorage.getItem('nickname');
+      setNickname(storedNickname || ''); // 기본값은 빈 문자열
+    };
+
+    // 게시글을 가져오는 함수
+    const fetchPosts = async () => {
+      try {
+        const response = await axios.get('http://localhost:8080/api/posts', {
+          params: {
+            page: currentPage,
+            pageSize: postsPerPage,
+            sortBy: 'createdAt,desc',
+            userName: email, // 이메일을 userName 파라미터로 설정
+          },
+        });
+
+        const { content, totalPages } = response.data.data;
+        setPosts(transformPostData(content));
+        setTotalPages(totalPages);
+      } catch (error) {
+        console.error('Error fetching posts:', error);
+      }
+    };
+
+    fetchNickname(); // 닉네임을 먼저 가져옴
+    fetchPosts(); // 게시글을 가져옴
+  }, [currentPage, email]); // 의존성 배열에서 email 추가
+
+  const transformPostData = (data) => {
+    const categoryMapping = {
+      "BOAST": "자랑하기",
+      "FREEDOM": "자유게시판"
+    };
+
+    return data.map(post => ({
+      id: post.id,
+      category: categoryMapping[post.category] || post.category,
+      title: post.title,
+      nickname: post.nickname,
+      createdTime: new Date(post.createAt).toLocaleDateString(),
+      likes: post.likeCount,
+    }));
+  };
+
+  const handlePageChange = (pageNumber) => {
+    if (pageNumber >= 1 && pageNumber <= totalPages) {
+      setCurrentPage(pageNumber);
+    }
+  };
+
+  const navigateToPost = (post) => {
+    const targetPath = post.category === '자랑하기' ? `/pet/${post.id}` : `/posts/${post.id}`;
+    navigate(targetPath);
+  };
+
+  const goToMyPage = () => {
+    navigate('/profile');
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h2 className={styles.heading}>{nickname ? `${nickname}의 게시글 목록` : '게시글 목록'}</h2>
+        <button onClick={goToMyPage} className={styles.button}>
+          ← 마이페이지
+        </button>
+      </div>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>카테고리</th>
+            <th>제목</th>
+            <th>좋아요 수</th>
+            <th>작성자</th>
+            <th>작성일자</th>
+          </tr>
+        </thead>
+        <tbody>
+          {posts.length > 0 ? (
+            posts.map(post => (
+              <tr key={post.id} onClick={() => navigateToPost(post)} className={styles.clickableRow}>
+                <td>{post.category}</td>
+                <td>{post.title}</td>
+                <td>{post.likes}</td>
+                <td>{post.nickname}</td>
+                <td>{post.createdTime}</td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td colSpan="5">게시물이 없습니다.</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+
+      <PaginationButton
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={handlePageChange}
+      />
+    </div>
+  );
+};
+
+export default MyPostList;

--- a/src/components/PetCardPost.jsx
+++ b/src/components/PetCardPost.jsx
@@ -212,7 +212,7 @@ const PetCardPost = () => {
   }
 
   const handleBoardClick = () => {
-    navigate('/community');
+    navigate('/gallery');
   };
 
   const isPostOwner = post && post.postUserId === currentUserId;

--- a/src/components/PetCardPost.jsx
+++ b/src/components/PetCardPost.jsx
@@ -212,7 +212,7 @@ const PetCardPost = () => {
   }
 
   const handleBoardClick = () => {
-    navigate('/gallery');
+    navigate(-1);
   };
 
   const isPostOwner = post && post.postUserId === currentUserId;

--- a/src/components/PostDetail.jsx
+++ b/src/components/PostDetail.jsx
@@ -320,7 +320,7 @@ const PostDetail = () => {
     };
 
     const handleBoardClick = () => {
-        navigate('/freedom');
+        navigate(-1);
     };
 
     const isPostOwner = post && post.postUserId === currentUserId;

--- a/src/components/PostDetail.jsx
+++ b/src/components/PostDetail.jsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import styles from '../styles/PostDetail.module.css';
 import { SlArrowUpCircle } from "react-icons/sl";
-import { MdEdit, MdAddCircleOutline } from 'react-icons/md';
+import { MdEdit } from 'react-icons/md';
 import { GoAlertFill } from "react-icons/go";
 import { FaTrashAlt } from 'react-icons/fa';
 import Comment from '../components/Comment';
@@ -320,7 +320,7 @@ const PostDetail = () => {
     };
 
     const handleBoardClick = () => {
-        navigate('/community');
+        navigate('/freedom');
     };
 
     const isPostOwner = post && post.postUserId === currentUserId;

--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import UserEditModal from '../components/UserEditModal';
 import ChangePasswordModal from './ChangePasswordModal';
 import WithdrawModal from '../components/WithdrawModal';
 import styles from '../styles/Profile.module.css';
-import { useNavigate } from 'react-router-dom';
 import RefreshToken from './RefreshToken';
 import handleLogout from './Logout';
 
@@ -242,7 +241,7 @@ const Profile = () => {
                 </div>
                 <div className={styles.rightContainer}>
                     <div className={styles.tableContainer}>
-                        <h2 className={styles.heading}>나의 최근 게시글 목록 [10개]</h2>
+                        <h2 className={styles.heading}>나의 최근 게시글 목록</h2>
                         <table className={styles.table}>
                             <thead>
                                 <tr>
@@ -264,12 +263,12 @@ const Profile = () => {
                                     ))
                                 ) : (
                                     <tr>
-                                        <td colSpan="3">게시물이 없습니다.</td>
+                                        <td colSpan="4">게시물이 없습니다.</td>
                                     </tr>
                                 )}
                             </tbody>
                         </table>
-                        <Link to="/community" className={styles.viewMore}>통합 게시판</Link>
+                        <Link to={`/my-post-list/${email}`} className={styles.viewMore}>더보기</Link>
                     </div>
                 </div>
             </div>

--- a/src/pages/MyPostListPage.jsx
+++ b/src/pages/MyPostListPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import MyPostList from '../components/MyPostList';
+
+const MyPostListPage = () => {
+  return (
+    <div className="my-post-list">
+      <MyPostList />
+    </div>
+  );
+};
+
+export default MyPostListPage;

--- a/src/styles/Profile.module.css
+++ b/src/styles/Profile.module.css
@@ -78,19 +78,22 @@
     box-shadow: 0 0 0 2px #3e232c;
 }
 
-.rightContainer>div {
-    flex: 1;
-    background-color: #ffffff;
-    border-radius: 8px;
-    border: 1px solid #ddd;
-    padding: 15px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+.rightContainer {
+    flex: 2; /* flex 속성을 조정하여 더 많은 공간을 차지하도록 설정 */
+    margin-top: 30px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
 }
 
 .tableContainer {
     background-color: #ffffff; /* 흰색 배경 */
     border-radius: 8px;
+    border: 1px solid #ddd;
     padding: 15px;
+    max-width: 90%; /* 최대 너비를 90%로 설정하여 줄임 */
+    width: 100%; /* 상자의 너비를 100%로 설정 */
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
 .table {
@@ -147,13 +150,13 @@
 /* 작성 일자 */
 .table th:nth-child(3),
 .table td:nth-child(3) {
-    width: 22%; /* 원하는 너비로 조정 */
+    width: 20%; /* 원하는 너비로 조정 */
 }
 
 /* 좋아요 수 */
 .table th:nth-child(4),
-.table td:nth-child(5) {
-    width: 18%;
+.table td:nth-child(4) {
+    width: 20%;
 }
 
 .postLink {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#105 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 스크린샷 (선택)

### 1. 프로필 게시물 목록 너비 수정

프로필 페이지의 게시물 목록 상자의 가로 너비를 조정하여 게시물 목록이 더 잘 보이도록 수정

![image](https://github.com/user-attachments/assets/5becc581-2900-4289-96f7-e4d7b316a43e)


### 2. 최근 게시물 10개 표시 및 더보기 연동

프로필 페이지에서 최근 게시물 10개를 표시하고, "더보기"를 추가하여 사용자가 전체 게시글 목록을 조회할 수 있음
"더보기" 클릭 시 사용자의 게시글 목록으로 이동

![image](https://github.com/user-attachments/assets/e6cc4320-0b91-4f19-8582-99cc7389c54c)

### 3. 게시물 단건 조회에서 뒤로가기 버튼 수정

게시물 단건 조회 페이지에서 "뒤로가기" 버튼 클릭 시, 이전에 열었던 카테고리에 맞는 게시물 목록으로 이동하도록 수정
![나만_-펫-Chrome-2024-07-31-19-43-36](https://github.com/user-attachments/assets/fc85e20d-4b6f-4c99-ac49-4646aedc508c)
